### PR TITLE
Bootstrap NestJS backend and Vite admin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,9 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Node
+node_modules/
+backend/dist/
+frontend/dist/
+coverage/

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  coverageDirectory: '../coverage',
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "field-service-backend",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "nest start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.2.0",
+    "supertest": "^6.3.0"
+  }
+}

--- a/backend/src/controllers/clients.controller.ts
+++ b/backend/src/controllers/clients.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { ClientsService } from '../services/clients.service';
+import { Client } from '../entities/client.entity';
+
+@Controller('clients')
+export class ClientsController {
+  constructor(private readonly clients: ClientsService) {}
+
+  @Get()
+  findAll(): Promise<Client[]> {
+    return this.clients.findAll();
+  }
+
+  @Post()
+  create(@Body() data: Partial<Client>): Promise<Client> {
+    return this.clients.create(data);
+  }
+}

--- a/backend/src/controllers/visits.controller.ts
+++ b/backend/src/controllers/visits.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { VisitsService } from '../services/visits.service';
+import { Visit } from '../entities/visit.entity';
+
+@Controller('visits')
+export class VisitsController {
+  constructor(private readonly visits: VisitsService) {}
+
+  @Get()
+  findAll(): Promise<Visit[]> {
+    return this.visits.findAll();
+  }
+
+  @Post()
+  create(@Body() data: Partial<Visit>): Promise<Visit> {
+    return this.visits.create(data);
+  }
+}

--- a/backend/src/entities/base.entity.ts
+++ b/backend/src/entities/base.entity.ts
@@ -1,0 +1,12 @@
+import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export abstract class BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/entities/client.entity.ts
+++ b/backend/src/entities/client.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, OneToMany } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Visit } from './visit.entity';
+
+@Entity()
+export class Client extends BaseEntity {
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  email?: string;
+
+  @OneToMany(() => Visit, (visit) => visit.client)
+  visits: Visit[];
+}

--- a/backend/src/entities/visit.entity.ts
+++ b/backend/src/entities/visit.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Client } from './client.entity';
+
+@Entity()
+export class Visit extends BaseEntity {
+  @Column()
+  scheduledAt: Date;
+
+  @Column({ default: 'pending' })
+  status: string;
+
+  @ManyToOne(() => Client, (client) => client.visits)
+  client: Client;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './modules/app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/backend/src/migrations/1680000000000-Init.ts
+++ b/backend/src/migrations/1680000000000-Init.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Init1680000000000 implements MigrationInterface {
+  name = 'Init1680000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE "client" ("id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(), "name" varchar NOT NULL, "email" varchar, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now())`);
+    await queryRunner.query(`CREATE TABLE "visit" ("id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(), "scheduledAt" TIMESTAMP NOT NULL, "status" varchar NOT NULL DEFAULT 'pending', "clientId" uuid, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now())`);
+    await queryRunner.query(`ALTER TABLE "visit" ADD CONSTRAINT "FK_client" FOREIGN KEY ("clientId") REFERENCES "client"("id") ON DELETE SET NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "visit" DROP CONSTRAINT "FK_client"`);
+    await queryRunner.query(`DROP TABLE "visit"`);
+    await queryRunner.query(`DROP TABLE "client"`);
+  }
+}

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ClientsModule } from './clients.module';
+import { VisitsModule } from './visits.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'fieldservice',
+      entities: [__dirname + '/../entities/*.entity{.ts,.js}'],
+      synchronize: false,
+    }),
+    ClientsModule,
+    VisitsModule,
+  ],
+})
+export class AppModule {}

--- a/backend/src/modules/clients.module.ts
+++ b/backend/src/modules/clients.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Client } from '../entities/client.entity';
+import { ClientsService } from '../services/clients.service';
+import { ClientsController } from '../controllers/clients.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Client])],
+  providers: [ClientsService],
+  controllers: [ClientsController],
+})
+export class ClientsModule {}

--- a/backend/src/modules/visits.module.ts
+++ b/backend/src/modules/visits.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Visit } from '../entities/visit.entity';
+import { VisitsService } from '../services/visits.service';
+import { VisitsController } from '../controllers/visits.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Visit])],
+  providers: [VisitsService],
+  controllers: [VisitsController],
+})
+export class VisitsModule {}

--- a/backend/src/services/clients.service.ts
+++ b/backend/src/services/clients.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Client } from '../entities/client.entity';
+
+@Injectable()
+export class ClientsService {
+  constructor(@InjectRepository(Client) private repo: Repository<Client>) {}
+
+  findAll(): Promise<Client[]> {
+    return this.repo.find();
+  }
+
+  create(data: Partial<Client>): Promise<Client> {
+    const client = this.repo.create(data);
+    return this.repo.save(client);
+  }
+}

--- a/backend/src/services/visits.service.ts
+++ b/backend/src/services/visits.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Visit } from '../entities/visit.entity';
+import { Client } from '../entities/client.entity';
+
+@Injectable()
+export class VisitsService {
+  constructor(@InjectRepository(Visit) private repo: Repository<Visit>) {}
+
+  findAll(): Promise<Visit[]> {
+    return this.repo.find({ relations: ['client'] });
+  }
+
+  create(data: Partial<Visit>): Promise<Visit> {
+    const visit = this.repo.create(data);
+    return this.repo.save(visit);
+  }
+}

--- a/backend/test/app.spec.ts
+++ b/backend/test/app.spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/modules/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/GET clients (empty)', () => {
+    return request(app.getHttpServer())
+      .get('/clients')
+      .expect(200)
+      .expect([]);
+  });
+});

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Field Service Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "field-service-admin",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "vite": "^5.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,22 @@
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import Clients from './pages/Clients';
+import Calendar from './pages/Calendar';
+import JobBoard from './pages/JobBoard';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <nav>
+        <Link to="/clients">Clients</Link> |{' '}
+        <Link to="/calendar">Calendar</Link> |{' '}
+        <Link to="/jobs">Job Board</Link>
+      </nav>
+      <Routes>
+        <Route path="/clients" element={<Clients />} />
+        <Route path="/calendar" element={<Calendar />} />
+        <Route path="/jobs" element={<JobBoard />} />
+        <Route path="/" element={<Clients />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -1,0 +1,8 @@
+export default function Calendar() {
+  return (
+    <div>
+      <h1>Calendar</h1>
+      <p>Calendar view coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+interface Client {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+export default function Clients() {
+  const [clients, setClients] = useState<Client[]>([]);
+
+  useEffect(() => {
+    fetch('/api/clients')
+      .then((res) => res.json())
+      .then(setClients);
+  }, []);
+
+  return (
+    <div>
+      <h1>Clients</h1>
+      <ul>
+        {clients.map((c) => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/JobBoard.tsx
+++ b/frontend/src/pages/JobBoard.tsx
@@ -1,0 +1,8 @@
+export default function JobBoard() {
+  return (
+    <div>
+      <h1>Job Board</h1>
+      <p>Job list will appear here.</p>
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3001,
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a simple NestJS backend with TypeORM
- add basic entities, service and controller examples
- include an initial migration and Jest test stub
- set up a basic React admin UI using Vite

## Testing
- `npm test --prefix backend` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68890cca66c08323bf8d0eaeb8839fcc