### PR TITLE
Update README and add Makefile helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: backend frontend test-backend
+
+backend:
+	cd backend && npm install && npm start
+
+frontend:
+	cd frontend && npm install && npm run dev
+
+test-backend:
+	cd backend && npm install && npm test

--- a/README.md
+++ b/README.md
@@ -13,3 +13,46 @@ python src/hello.py [name]
 
 Replace `[name]` with your desired name. If no name is provided, the script
 defaults to `World`.
+
+## Backend API
+
+Install dependencies and start the NestJS backend:
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+Run tests once dependencies are installed:
+
+```bash
+npm test
+```
+
+## Frontend App
+
+To run the React/Vite frontend:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Makefile Helpers
+
+For convenience, a `Makefile` is provided with shortcuts to common tasks:
+
+```bash
+# start the backend server
+make backend
+
+# start the React frontend
+make frontend
+
+# run backend tests
+make test-backend
+```
+
+These targets simply wrap the same `npm` commands shown above.


### PR DESCRIPTION
## Summary
- add Makefile with targets for backend, frontend, and tests
- document Makefile usage in README

## Testing
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688912c27fbc8323ad1acc35596347e7