### PR TITLE
Read database config from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=postgres
+DB_NAME=fieldservice

--- a/README.md
+++ b/README.md
@@ -13,3 +13,24 @@ python src/hello.py [name]
 
 Replace `[name]` with your desired name. If no name is provided, the script
 defaults to `World`.
+
+## Configuring the Backend
+
+The NestJS backend uses environment variables for its Postgres connection. For
+local development, create a `.env` file in the project root based on the
+provided example:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set the following variables to match your local database:
+
+- `DB_HOST` – database host
+- `DB_PORT` – database port
+- `DB_USER` – database username
+- `DB_PASS` – database password
+- `DB_NAME` – name of the database
+
+When these variables are set, running the backend with `npm start` will connect
+to your configured Postgres instance.

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -7,11 +7,11 @@ import { VisitsModule } from './visits.module';
   imports: [
     TypeOrmModule.forRoot({
       type: 'postgres',
-      host: 'localhost',
-      port: 5432,
-      username: 'postgres',
-      password: 'postgres',
-      database: 'fieldservice',
+      host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT, 10),
+      username: process.env.DB_USER,
+      password: process.env.DB_PASS,
+      database: process.env.DB_NAME,
       entities: [__dirname + '/../entities/*.entity{.ts,.js}'],
       synchronize: false,
     }),


### PR DESCRIPTION
## Summary
- make DB config in backend configurable via environment variables
- add `.env.example` to show required variables
- document how to set up these variables for local development

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688912c1c1508323a6b11141853f76f5